### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Update yaru_window_linux & yaru_window_web.
+
 ## 0.1.0
 
 - Initial version.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: yaru_window
 description: Provides API for interacting with top-level windows.
 repository: https://github.com/ubuntu-flutter-community/yaru_window.dart
 issue_tracker: https://github.com/ubuntu-flutter-community/yaru_window.dart/issues
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: '>=2.19.0 <3.0.0'


### PR DESCRIPTION
* Update CI by @jpnurmi in https://github.com/ubuntu-flutter-community/yaru_window.dart/pull/9
* Web: window state by @jpnurmi in https://github.com/ubuntu-flutter-community/yaru_window.dart/pull/10
* Update dependency yaru_window_web to ^0.0.2 by @renovate in https://github.com/ubuntu-flutter-community/yaru_window.dart/pull/11
* yaru_window_linux: emit button release at drag end by @jpnurmi in https://github.com/ubuntu-flutter-community/yaru_window.dart/pull/12
