### PR TITLE
CI: pin melos at 2.9.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v2
+        with:
+          melos-version: '2.9.0'
       - run: melos analyze
 
   coverage:
@@ -22,6 +24,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v2
+        with:
+          melos-version: '2.9.0'
       - run: sudo apt update
       - run: sudo apt install -y lcov
       - run: melos coverage
@@ -35,6 +39,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v2
+        with:
+          melos-version: '2.9.0'
       - run: melos format
 
   linux:
@@ -76,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
-      - run: dart pub global activate melos
+      - run: dart pub global activate melos 2.9.0
       - run: melos exec -c 1 --no-private -- dart pub publish --dry-run
 
   test:
@@ -85,6 +91,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v2
+        with:
+          melos-version: '2.9.0'
       - run: melos test
 
   web:
@@ -93,6 +101,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v2
+        with:
+          melos-version: '2.9.0'
       - run: flutter pub get
         working-directory: example
       - run: flutter build web -v


### PR DESCRIPTION
Pin for now, we can migrate to 3.x later.
```
Activated melos 3.0.0.
Running melos bootstrap...
Found a melos.yaml file in "/home/runner/work/yaru_window.dart/yaru_window.dart" but no local installation of Melos.

From version 3.0.0, the melos package must be installed in a pubspec.yaml file next to the melos.yaml file.

For more information on migrating to version 3.0.0, see: https://melos.invertase.dev/guides/migrations#200-to-300

To migrate at a later time, ensure you have version 2.9.0 or below installed: dart pub global activate melos 2.9.0
```
https://github.com/ubuntu-flutter-community/yaru_window.dart/actions/runs/4490076858/jobs/7896692533?pr=16