### PR TITLE
Protect YaruTestWindow.close() against concurrency

### DIFF
--- a/packages/yaru_window_test/lib/src/test_window.dart
+++ b/packages/yaru_window_test/lib/src/test_window.dart
@@ -37,7 +37,8 @@ class YaruTestWindow extends YaruWindowPlatform {
 
   @override
   Future<void> close(int id) async {
-    for (final handler in _onCloseHandlers) {
+    while (_onCloseHandlers.isNotEmpty) {
+      final handler = _onCloseHandlers.removeAt(0);
       if (!await handler()) {
         break;
       }


### PR DESCRIPTION
One handler may be executed while another gets inserted.