### PR TITLE
fix(yaru_window_manager): remove linux from the list of platforms

### DIFF
--- a/packages/yaru_window_manager/pubspec.yaml
+++ b/packages/yaru_window_manager/pubspec.yaml
@@ -27,8 +27,6 @@ flutter:
   plugin:
     implements: yaru_window
     platforms:
-      linux:
-        dartPluginClass: YaruWindowManager
       macos:
         dartPluginClass: YaruWindowManager
       windows:


### PR DESCRIPTION
Linux support is provided by `yaru_window_linux` instead.