### PR TITLE
chore(melos): update config

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -3,13 +3,10 @@ name: yaru_window
 packages:
   - .
   - packages/**
+  - example
 
 ignore:
   - synthetic_package
-
-command:
-  bootstrap:
-    usePubspecOverrides: true
 
 scripts:
   # analyze all packages


### PR DESCRIPTION
- remove the old `usePubspecOverrides` - no longer used with Melos 3.x
- add example to ensure it gets bootstrapped with the local deps too