### PR TITLE
fix: `_handleClose` conditioned to the state stream

### DIFF
--- a/packages/yaru_window_manager/lib/src/window_manager.dart
+++ b/packages/yaru_window_manager/lib/src/window_manager.dart
@@ -12,8 +12,13 @@ class YaruWindowManager extends YaruWindowPlatform {
     YaruWindowPlatform.instance = YaruWindowManager();
   }
 
-  _YaruWindowListener? __listener;
-  _YaruWindowListener get _listener => __listener ??= _YaruWindowListener(_wm);
+  _YaruWindowStatesListener? __statesListener;
+  _YaruWindowStatesListener get _listener =>
+      __statesListener ??= _YaruWindowStatesListener(_wm);
+
+  _YaruWindowOnCloseListener? __closeListener;
+  _YaruWindowOnCloseListener get _closeListener =>
+      __closeListener ??= _YaruWindowOnCloseListener(_wm);
 
   WindowManager? __wm;
   WindowManager get _wm => __wm ??= WindowManager.instance;
@@ -88,7 +93,7 @@ class YaruWindowManager extends YaruWindowPlatform {
 
   @override
   Future<void> onClose(int id, FutureOr<bool> Function() handler) {
-    return _listener.addCloseHandler(handler);
+    return _closeListener.addCloseHandler(handler);
   }
 }
 
@@ -159,8 +164,8 @@ extension _YaruWindowManagerX on WindowManager {
   }
 }
 
-class _YaruWindowListener extends WindowListener {
-  _YaruWindowListener(this._wm);
+class _YaruWindowStatesListener extends WindowListener {
+  _YaruWindowStatesListener(this._wm);
 
   final WindowManager _wm;
   StreamController<YaruWindowState>? _controller;
@@ -195,6 +200,15 @@ class _YaruWindowListener extends WindowListener {
   void onWindowMinimize() => _updateState();
   @override
   void onWindowRestore() => _updateState();
+}
+
+class _YaruWindowOnCloseListener extends WindowListener {
+  _YaruWindowOnCloseListener(this._wm) {
+    _wm.addListener(this);
+  }
+
+  final WindowManager _wm;
+
   @override
   void onWindowClose() => _handleClose();
 


### PR DESCRIPTION
By splitting the `WindowListener` in two pieces, one dedicated to the `onClose` event, subscribed unconditionally.
The semantics of the other states remain unchanged.

Fixes #29

Stopping at 226322d2a168a09f5da42828e1425696af1d71fc and running `flutter test` on the `yaru_window_manager` package fails:

```
00:03 +5 -1: calls close handlers [E]
  Expected: <true>
    Actual: <false>
  Close handlers never called.

  package:matcher                                     expect
  package:flutter_test/src/widget_tester.dart 459:16  expect
  test\window_manager_test.dart 230:5                 main.<fn>
```

With the supplied fix all tests should pass.