### PR TITLE
chore(release): publish packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,47 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-08-13
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`yaru_window` - `v0.2.2`](#yaru_window---v022)
+ - [`yaru_window_linux` - `v0.2.2`](#yaru_window_linux---v022)
+ - [`yaru_window_manager` - `v0.1.3`](#yaru_window_manager---v013)
+ - [`yaru_window_platform_interface` - `v0.1.3`](#yaru_window_platform_interface---v013)
+ - [`yaru_window_web` - `v0.0.4`](#yaru_window_web---v004)
+
+---
+
+#### `yaru_window` - `v0.2.2`
+
+ - **CHORE**: update Flutter to 3.32.0
+
+#### `yaru_window_linux` - `v0.2.2`
+
+ - **CHORE**: update Flutter to 3.32.0
+
+#### `yaru_window_manager` - `v0.1.3`
+
+ - update Flutter to 3.32.0 and window_manager to 0.5.1
+
+#### `yaru_window_platform_interface` - `v0.1.3`
+
+ - **CHORE**: update Flutter to 3.32.0
+
+#### `yaru_window_web` - `v0.0.4`
+
+ - **CHORE**: update FLutter to 3.32.0
+
+
 ## 2024-09-20
 
 ### Changes

--- a/packages/yaru_window/CHANGELOG.md
+++ b/packages/yaru_window/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+ - **CHORE**: update Flutter to 3.32.0
+
 ## 0.2.1+1
 
  - Update a dependency to the latest release.

--- a/packages/yaru_window/pubspec.yaml
+++ b/packages/yaru_window/pubspec.yaml
@@ -2,7 +2,7 @@ name: yaru_window
 description: Provides API for interacting with top-level windows.
 repository: https://github.com/ubuntu/yaru_window.dart
 issue_tracker: https://github.com/ubuntu/yaru_window.dart/issues
-version: 0.2.1+1
+version: 0.2.2
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
@@ -11,10 +11,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  yaru_window_linux: ^0.2.1
-  yaru_window_manager: ^0.1.2+1
-  yaru_window_platform_interface: ^0.1.2+1
-  yaru_window_web: ^0.0.3+1
+  yaru_window_linux: ^0.2.2
+  yaru_window_manager: ^0.1.3
+  yaru_window_platform_interface: ^0.1.3
+  yaru_window_web: ^0.0.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/yaru_window_linux/CHANGELOG.md
+++ b/packages/yaru_window_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+ - **CHORE**: update Flutter to 3.32.0
+
 ## 0.2.1
 
  - **FIX**(linux): wire up YaruWindow.onClose with didRequestAppExit() (#35).

--- a/packages/yaru_window_linux/pubspec.yaml
+++ b/packages/yaru_window_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: yaru_window_linux
 description: A Linux implementation of yaru_window.
 repository: https://github.com/ubuntu/yaru_window.dart
 issue_tracker: https://github.com/ubuntu/yaru_window.dart/issues
-version: 0.2.1
+version: 0.2.2
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/yaru_window_manager/CHANGELOG.md
+++ b/packages/yaru_window_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+ - update Flutter to 3.32.0 and window_manager to 0.5.1
+
 ## 0.1.2+1
 
  - **FIX**: `_handleClose` conditioned to the state stream (#31).

--- a/packages/yaru_window_manager/pubspec.yaml
+++ b/packages/yaru_window_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   A window_manager -based implementation of yaru_window for macOS and Windows.
 repository: https://github.com/ubuntu/yaru_window.dart
 issue_tracker: https://github.com/ubuntu/yaru_window.dart/issues
-version: 0.1.2+1
+version: 0.1.3
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
@@ -15,7 +15,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   window_manager: ^0.5.1
-  yaru_window_platform_interface: ^0.1.2+1
+  yaru_window_platform_interface: ^0.1.3
 
 dev_dependencies:
   flutter_test:

--- a/packages/yaru_window_platform_interface/CHANGELOG.md
+++ b/packages/yaru_window_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+ - **CHORE**: update Flutter to 3.32.0
+
 ## 0.1.2+1
 
  - **FIX**(linux): wire up YaruWindow.onClose with didRequestAppExit() (#35).

--- a/packages/yaru_window_platform_interface/pubspec.yaml
+++ b/packages/yaru_window_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: yaru_window_platform_interface
 description: A common platform interface for yaru_window
 repository: https://github.com/ubuntu/yaru_window.dart
 issue_tracker: https://github.com/ubuntu/yaru_window.dart/issues
-version: 0.1.2+1
+version: 0.1.3
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/yaru_window_web/CHANGELOG.md
+++ b/packages/yaru_window_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+ - **CHORE**: update FLutter to 3.32.0
+
 ## 0.0.3+1
 
  - Update a dependency to the latest release.

--- a/packages/yaru_window_web/pubspec.yaml
+++ b/packages/yaru_window_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: yaru_window_web
 description: A stub implementation of yaru_window for Web.
 repository: https://github.com/ubuntu/yaru_window.dart
 issue_tracker: https://github.com/ubuntu/yaru_window.dart/issues
-version: 0.0.3+1
+version: 0.0.4
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  yaru_window_platform_interface: ^0.1.2+1
+  yaru_window_platform_interface: ^0.1.3
 
 dev_dependencies:
   ubuntu_lints: ^0.4.1+1


### PR DESCRIPTION
Publish for

 - yaru_window@0.2.2
 - yaru_window_linux@0.2.2
 - yaru_window_manager@0.1.3
 - yaru_window_platform_interface@0.1.3
 - yaru_window_web@0.0.4

Related https://github.com/ubuntu/yaru_window.dart/pull/61

Once this is merged the packages can be pushed to pub.dev.